### PR TITLE
Fix security report modal stacking on component detail and submissions pages

### DIFF
--- a/src/pages/ComponentDetail.tsx
+++ b/src/pages/ComponentDetail.tsx
@@ -33,6 +33,7 @@ import {
 } from "@radix-ui/react-icons";
 import { AgentInstallSection } from "../components/AgentInstallSection";
 import { FileArrowDown, ClipboardText, DiscordLogo, ShieldCheck, ShieldWarning, Shield } from "@phosphor-icons/react";
+import { createPortal } from "react-dom";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import remarkBreaks from "remark-breaks";
@@ -525,7 +526,11 @@ function SecurityReportModal({
         : "Scanned";
   const hasFindings = scanData.findings.length > 0 || scanData.recommendations.length > 0;
 
-  return (
+  if (typeof document === "undefined") {
+    return null;
+  }
+
+  return createPortal(
     <div
       className="fixed inset-0 z-[120] flex items-start justify-center p-4 pt-8 sm:pt-12"
       aria-modal="true"
@@ -677,7 +682,8 @@ function SecurityReportModal({
           </button>
         </div>
       </div>
-    </div>
+    </div>,
+    document.body,
   );
 }
 

--- a/src/pages/Submit.tsx
+++ b/src/pages/Submit.tsx
@@ -2,6 +2,7 @@ import { useAction, useMutation, useQuery } from "convex/react";
 import { api } from "../../convex/_generated/api";
 import { Toaster, toast } from "sonner";
 import { useState, useEffect, useRef, useMemo } from "react";
+import { createPortal } from "react-dom";
 import { Id } from "../../convex/_generated/dataModel";
 import { useDirectoryCategories } from "../lib/categories";
 import Header from "../components/Header";
@@ -1965,7 +1966,11 @@ function SubmitSecurityReportModal({
         : "Scanned";
   const hasFindings = scanData.findings.length > 0 || scanData.recommendations.length > 0;
 
-  return (
+  if (typeof document === "undefined") {
+    return null;
+  }
+
+  return createPortal(
     <div
       className="fixed inset-0 z-[120] flex items-start justify-center p-4 pt-8 sm:pt-12"
       aria-modal="true"
@@ -2107,7 +2112,8 @@ function SubmitSecurityReportModal({
           </button>
         </div>
       </div>
-    </div>
+    </div>,
+    document.body,
   );
 }
 
@@ -2463,4 +2469,3 @@ function PackageRow({
     </div>
   );
 }
-


### PR DESCRIPTION
Im not sure whether you’re currently accepting contributions on this repo, but I noticed a small UI issue and put together a focused fix for it.

This fixes a layering issue with the public "Security Analyze" modal.

On pages like the Rate Limiter component, the modal was rendered inside the sticky sidebar, which caused it to sit inside a local stacking context. As a result, main-content code blocks could overlap the modal.

This change renders the security report modals through `createPortal(..., document.body)` so they mount at the document root and reliably overlay the page.

Files changed:
- `src/pages/ComponentDetail.tsx`
- `src/pages/Submit.tsx`

Verification:
- Reproduced locally on `/components/rate-limiter`
- `bun run build`
- `bunx tsc -p . -noEmit --pretty false`
- `bunx tsc -p convex -noEmit --pretty false`

Before:
<img width="3024" height="1820" alt="image" src="https://github.com/user-attachments/assets/f6e065d4-9db9-43ad-ba42-0315ac10e4af" />

After:
<img width="3024" height="1710" alt="image" src="https://github.com/user-attachments/assets/02a26766-45cd-4fbb-9f1d-dd7abcbbee1a" />

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
