### PR TITLE
Mirror all comments/notes to Slack

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Slack now mirrors all admin-visible write paths on a component (2026-04-18)
+  - `addPackageComment`: removed the `if (!isAdmin)` gate so admin replies also notify Slack; `From:` label is now `Admin` or `Submitter` based on role.
+  - `requestSubmissionRefresh`: added Slack notification when a submitter clicks "Send Request" from Profile.
+  - `addPackageNote`: added Slack notification for admin internal notes (`Internal admin note on ...`) and legacy `[User Request]` replies (`Admin reply (legacy request) on ...`).
+  - File changed: `convex/packages.ts`
+
 ### Fixed
 
 - Admin mobile settings and API layouts now fit narrow screens cleanly (2026-04-17 23:04 UTC)

--- a/convex/packages.ts
+++ b/convex/packages.ts
@@ -61,6 +61,23 @@ function userOwnsPackage(pkg: Doc<"packages">, userEmail: string): boolean {
   return false;
 }
 
+function formatSlackNotification(
+  pkg: Doc<"packages">,
+  headline: string,
+  fromLabel: string,
+  content: string,
+): string {
+  const slugForUrl = pkg.slug ?? pkg.name;
+  const displayName = `${pkg.componentName ?? pkg.name} (${pkg.name})`;
+  const preview = content.length > 200 ? `${content.slice(0, 200)}...` : content;
+  return (
+    `${headline} ${displayName}\n` +
+    `From: ${fromLabel}\n` +
+    `https://www.convex.dev/components/${slugForUrl}\n` +
+    `Preview: ${preview}`
+  );
+}
+
 async function requirePackageOwnerOrAdmin(
   ctx: MutationCtx,
   packageId: Id<"packages">,
@@ -2187,7 +2204,7 @@ export const addPackageNote = mutation({
     }
 
     // Insert the internal admin note with timestamp-based ordering.
-    return await ctx.db.insert("packageNotes", {
+    const noteId = await ctx.db.insert("packageNotes", {
       packageId: args.packageId,
       content: args.content,
       authorEmail: adminEmail,
@@ -2197,6 +2214,18 @@ export const addPackageNote = mutation({
       isAdminReply: isAdminReply || undefined,
       userHasRead: isAdminReply ? false : undefined,
     });
+
+    // Mirror admin notes to Slack.
+    const pkg = await ctx.db.get("packages", args.packageId);
+    if (pkg) {
+      const headline = isAdminReply
+        ? "Admin reply (legacy request) on"
+        : "Internal admin note on";
+      const text = formatSlackNotification(pkg, headline, `Admin (${adminEmail})`, args.content);
+      await ctx.scheduler.runAfter(0, internal.slack.sendMessage, { text });
+    }
+
+    return noteId;
   },
 });
 
@@ -3379,18 +3408,10 @@ export const addPackageComment = mutation({
       status: "active",
     });
 
-    // Notify via Slack when a submitter sends a new message.
-    if (!isAdmin) {
-      const slugForUrl = pkg.slug ?? pkg.name;
-      const preview =
-        args.content.length > 200 ? `${args.content.slice(0, 200)}...` : args.content;
-      const slackText =
-        `New private message on ${pkg.componentName ?? pkg.name} (${pkg.name})\n` +
-        `From: Submitter (${userEmail})\n` +
-        `https://www.convex.dev/components/${slugForUrl}\n` +
-        `Preview: ${preview}`;
-      await ctx.scheduler.runAfter(0, internal.slack.sendMessage, { text: slackText });
-    }
+    // Notify via Slack when a private message is added.
+    const fromLabel = isAdmin ? `Admin (${userEmail})` : `Submitter (${userEmail})`;
+    const text = formatSlackNotification(pkg, "New private message on", fromLabel, args.content);
+    await ctx.scheduler.runAfter(0, internal.slack.sendMessage, { text });
 
     return commentId;
   },
@@ -4542,6 +4563,10 @@ export const requestSubmissionRefresh = mutation({
       userHasRead: true,
       status: "active",
     });
+
+    // Notify via Slack when a private message is added.
+    const text = formatSlackNotification(pkg, "New private message on", `Submitter (${userEmail})`, args.note);
+    await ctx.scheduler.runAfter(0, internal.slack.sendMessage, { text });
 
     return null;
   },

--- a/files.md
+++ b/files.md
@@ -210,7 +210,7 @@ Main package business logic. Contains:
 
 `submitPackage` now marks public submit-form packages as `communitySubmitted: true` by default so Admin loads the Community state correctly in both the Actions row and `ComponentDetailsEditor`. It also derives package ownership from the authenticated email instead of trusting the client-provided submitter email. When enabled, new submissions with a repository URL move to `in_review` and queue `runAiReview`. Enabling that same setting from the Admin page also moves current pending packages with repository URLs into `in_review` and queues AI review for them. `getAdminSettings` now returns the three-part AI automation model: `autoAiReview`, `autoApproveOnPass`, and `autoRejectOnFail`.
 
-**Helper Functions:** `toPublicPackage()`, `toAdminPackage()`, `generateSlugFromName()`, `userOwnsPackage()` (checks submitterEmail and additionalEmails), `getCurrentUserEmail()` (reads identity email claims), `scheduleSubmissionFollowups()` (Slack notify + optional auto AI review + auto security scan scheduling after `submitPackage` insert), `formatLatestSecurityScan()` (shapes the public-safe payload for `getLatestSecurityScan` from a package row + its latest `securityScanRuns` entry), `computeUnreadAdminReplySummary()` (per-package admin-reply unread rollup used by `getMyUnreadAdminRepliesByPackage`), validators
+**Helper Functions:** `toPublicPackage()`, `toAdminPackage()`, `generateSlugFromName()`, `userOwnsPackage()` (checks submitterEmail and additionalEmails), `getCurrentUserEmail()` (reads identity email claims), `formatSlackNotification()` (builds the standard Slack message with display name, URL, and 200-char preview; used by `addPackageComment`, `requestSubmissionRefresh`, and `addPackageNote`), `scheduleSubmissionFollowups()` (Slack notify + optional auto AI review + auto security scan scheduling after `submitPackage` insert), `formatLatestSecurityScan()` (shapes the public-safe payload for `getLatestSecurityScan` from a package row + its latest `securityScanRuns` entry), `computeUnreadAdminReplySummary()` (per-package admin-reply unread rollup used by `getMyUnreadAdminRepliesByPackage`), validators
 
 ### `convex/crons.ts`
 
@@ -234,7 +234,7 @@ Production: `npx convex run --prod seed:seedOfficialComponents '{"importAsPendin
 
 ### `convex/slack.ts`
 
-Internal Slack notifications: `sendMessage` (`internalAction`) POSTs `{ text }` to `SLACK_WEBHOOK_URL`. No-op if unset. Errors are logged only. Scheduled from `submitPackage` (new submissions), `addPackageComment` (private messages from the submitter only—not admin replies), and `packages._saveSecurityScanResultAndRun` when a security scan finishes.
+Internal Slack notifications: `sendMessage` (`internalAction`) POSTs `{ text }` to `SLACK_WEBHOOK_URL`. No-op if unset. Errors are logged only. Scheduled from `submitPackage` (new submissions), `addPackageComment` (private messages from both submitters and admins, with role-based `From:` label), `requestSubmissionRefresh` (submitter "Send Request" from Profile), `addPackageNote` (admin internal notes and legacy request replies, with distinct first-line labels), and `packages._saveSecurityScanResultAndRun` when a security scan finishes.
 
 ### `convex/thumbnails.ts`
 

--- a/task.md
+++ b/task.md
@@ -166,6 +166,12 @@ Session updates complete on 2026-04-17 23:04 UTC.
 
 ## to do
 
+- [x] Mirror all comment/note writes to Slack (2026-04-18)
+  - `addPackageComment`: removed `if (!isAdmin)` gate, Slack now fires for both admin and submitter with role-based `From:` label
+  - `requestSubmissionRefresh`: added Slack notification after `packageComments` insert (`From: Submitter`)
+  - `addPackageNote`: added Slack notification with branching first line for internal notes vs legacy `[User Request]` admin replies
+  - File changed: `convex/packages.ts`
+
 - [x] Add admin message notifications bell with dropdown and mark-all-read buttons (2026-04-17 06:17 UTC)
   - Added two new Convex public queries in `convex/packages.ts`: `getMyUnreadAdminRepliesByPackage` (user feed) and `getAdminUnreadMessagesByPackage` (admin-only feed, capped at 50 packages). Both return minimal metadata (`packageId`, `packageName`, `slug`, `unreadCount`, `lastMessageAt`) and reuse the existing `by_submitter_email` / `by_package_and_created` index patterns from `getTotalUnreadAdminReplies`. No schema changes.
   - Added Phosphor `Bell` (color `#E05C35`) in `src/components/Header.tsx` immediately right of the Submit link and in the mobile header row. Only rendered for authenticated users. Clicking opens a dropdown card with two sections: "Messages from Convex Team" and, for admins only, "Incoming messages". Total unread count appears as a round pill badge. Outside-click closes the dropdown.


### PR DESCRIPTION
Every insert into `packageComments` and `packageNotes` now triggers a Slack notification with a role-based label, so the triage channel sees the full thread instead of only submitter messages.

- `addPackageComment`: removed the `!isAdmin` gate; label is now "Admin" or "Submitter" based on role
- `requestSubmissionRefresh`: added Slack notify for "Send Request" from Profile
- `addPackageNote`: added Slack notify for internal notes and legacy `[User Request]` admin replies
- Extracted `formatSlackNotification` helper to deduplicate the message format across all three paths
- Updated `files.md`, `changelog.md`, and `task.md` to reflect the new behavior