### PR TITLE
Fix broken markdown URLs in llms.txt

### DIFF
--- a/convex/http.ts
+++ b/convex/http.ts
@@ -101,11 +101,14 @@ http.route({
         ? pkg.generatedDescription.slice(0, 200)
         : (pkg.seoValueProp || pkg.shortDescription || pkg.description || "");
       const category = pkg.category || "general";
+      const componentLinks = slug
+        ? buildComponentUrls(slug, DIRECTORY_ORIGIN)
+        : null;
       const url = slug
-        ? `https://www.convex.dev/components/${slug}`
+        ? componentLinks?.detailUrl || pkg.npmUrl
         : pkg.npmUrl;
       const mdUrl = slug
-        ? `https://www.convex.dev/api/markdown?slug=${slug}`
+        ? componentLinks?.markdownUrl || ""
         : "";
 
       lines.push(`## ${name}`);

--- a/convex/router.ts
+++ b/convex/router.ts
@@ -2,8 +2,10 @@ import { httpRouter } from "convex/server";
 import { httpAction } from "./_generated/server";
 import { internal } from "./_generated/api";
 import { normalizeMarkdown } from "../shared/normalizeMarkdown";
+import { buildComponentUrls } from "../shared/componentUrls";
 
 const http = httpRouter();
+const DIRECTORY_ORIGIN = "https://www.convex.dev";
 
 http.route({
   path: "/api/export-csv",
@@ -102,11 +104,14 @@ http.route({
       const desc =
         pkg.seoValueProp || pkg.shortDescription || pkg.description || "";
       const category = pkg.category || "general";
+      const componentLinks = slug
+        ? buildComponentUrls(slug, DIRECTORY_ORIGIN)
+        : null;
       const url = slug
-        ? `https://www.convex.dev/components/${slug}`
+        ? componentLinks?.detailUrl || pkg.npmUrl
         : pkg.npmUrl;
       const mdUrl = slug
-        ? `https://www.convex.dev/api/markdown?slug=${slug}`
+        ? componentLinks?.markdownUrl || ""
         : "";
 
       lines.push(`## ${name}`);


### PR DESCRIPTION
Fixes broken markdown links in `/api/llms.txt`. That endpoint was emitting `www.convex.dev/api/markdown?slug=...`, which 404s because `/api/markdown` only exists on the Convex deployment. It now uses `buildComponentUrls()` like the other endpoints.

Before: https://www.convex.dev/api/markdown?slug=convalytics-dev → 404
After: https://www.convex.dev/components/convalytics-dev/convalytics-dev.md → 200

Before: https://www.convex.dev/api/markdown?slug=ezyyeah/cloudflare-email-sending → 404
After: https://www.convex.dev/components/ezyyeah/cloudflare-email-sending/cloudflare-email-sending.md → 200